### PR TITLE
Add shared key management

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,53 @@
         </ul>
     </div>
 
+    <div id="shared-keys" class="d-none mt-4">
+        <h2>Shared Keys</h2>
+        <button id="create-shared-key" class="btn btn-success mb-3">Create Shared Key</button>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Kudos</th>
+                    <th>Expiry</th>
+                    <th>Utilized</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody id="shared-keys-list"></tbody>
+        </table>
+    </div>
+
+    <div class="modal fade" id="sharedKeyModal" tabindex="-1" aria-labelledby="sharedKeyModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="sharedKeyModalLabel"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="modal-name" class="form-label">Name</label>
+                        <input type="text" class="form-control" id="modal-name">
+                    </div>
+                    <div class="mb-3">
+                        <label for="modal-kudos" class="form-label">Kudos</label>
+                        <input type="number" class="form-control" id="modal-kudos" placeholder="-1 for unlimited">
+                    </div>
+                    <div class="mb-3">
+                        <label for="modal-expiry" class="form-label">Expiry (days)</label>
+                        <input type="number" class="form-control" id="modal-expiry" placeholder="-1 for never">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="save-key">Save</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
     <script src="script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- show shared keys after loading user info
- allow creating, editing and deleting shared keys with Bootstrap modal
- include API key header when fetching shared keys
- surface API error messages when shared key actions fail

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a9b513e0c832b86db68f178a0e31b